### PR TITLE
Fix compatibility format

### DIFF
--- a/telemeta/static/telemeta/js/playlist.js
+++ b/telemeta/static/telemeta/js/playlist.js
@@ -89,7 +89,13 @@ var playlistUtils = {
     },
 
     loadSong: function(resElem){
-        var audio = new Audio(resElem);
+        var audio = new Audio();
+	//For old browsers that do not support mp3 files 
+        audio.onerror = function(){
+             this.src = this.src.replace("mp3", "ogg");
+             this.play();
+	};
+	audio.src = resElem;
         audio.play();
     },
 


### PR DESCRIPTION
FIx compatibility by change format of file resource to "ogg" instead of "mp3" when an error occurs
 in an old browser like in my case Firefox 28.0
